### PR TITLE
Bugfix: Readme example sigsegv

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,16 +147,14 @@ func pinger(ch chan string, site string) {
 
 		if err != nil {
 			ch <- "-" + site
-		}
-
-		
-		if res.StatusCode != 200 {
-			ch <- "-" + site
 		} else {
-			ch <- "+" + site
+			if res.StatusCode != 200 {
+				ch <- "-" + site
+			} else {
+				ch <- "+" + site
+			}
+			res.Body.Close()
 		}
-		
-		res.Body.Close()
 		time.Sleep(30 * time.Second)
 	}
 }


### PR DESCRIPTION
When the requested server is completely non-responsive, and err!=nil,
res will be nil. The references to StatusCode and Body.Close() will
cause a SIGSEGV. If err!=nil, don’t reference res.

```
12:21:45:~/gowork/src/play/apistatus$ ./apistatus
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x2357]

goroutine 20 [running]:
panic(0x2150e0, 0xc42000c0e0)
	/usr/local/go/src/runtime/panic.go:500 +0x1a1
main.pinger(0xc420074ae0, 0x25f58e, 0x26)
	/Users/adam/gowork/src/play/apistatus/apistatus.go:51 +0x57
created by main.main
	/Users/adam/gowork/src/play/apistatus/apistatus.go:19 +0x99
```
